### PR TITLE
Wait for lab to finish before continuing

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,14 @@ module.exports = function (options) {
 
     // Spawn process
 
-    Spawn('node', args.concat(paths), {stdio: 'inherit'});
+    var child = Spawn('node', args.concat(paths), {stdio: 'inherit'});
 
-    cb();
+    child.on('exit', function () {
+
+      cb();
+
+    });
+
   });
 
 }


### PR DESCRIPTION
I had a problem chaining tasks with gulp-lab since it doesn't wait before Lab is done to continue.
It may be interesting to consider the exit number of Lab and report an error to gulp, but at least this patch is a start that fixes my problem.
