### PR TITLE
Emit error event for test case failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var Spawn = require('child_process').spawn;
 var Through2 = require('through2');
 var Join = require('path').join;
+var PluginError = require('gulp-util').PluginError;
+
+const PLUGIN_NAME = 'gulp-lab';
 
 module.exports = function (options) {
 
@@ -32,9 +35,12 @@ module.exports = function (options) {
 
     // Spawn process
     var child = Spawn('node', args.concat(paths), {stdio: 'inherit'});
+    var stream = this;
 
-    child.on('exit', function () {
-
+    child.on('exit', function (code) {
+      if (code !== 0) {
+        stream.emit('error', new PluginError(PLUGIN_NAME, 'Lab exited with errors.'));
+      }
       cb();
     });
 

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/otodockal/gulp-lab",
   "dependencies": {
+    "gulp-util": "~2.2.14",
     "through2": "~0.4.1"
   },
   "devDependencies": {
     "event-stream": "^3.1.5",
-    "gulp-util": "~2.2.14",
     "lab": "~3.1.1"
   }
 }

--- a/test/fail.js
+++ b/test/fail.js
@@ -1,0 +1,14 @@
+var Lab = require('lab');
+
+var it = Lab.test;
+var expect = Lab.expect;
+
+
+it('should fail test', function (done) {
+
+  console.log('\n\n');
+  
+  expect(true).equal(false);
+
+  done();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -34,4 +34,18 @@ describe('index', function () {
     stream.end(new Gutil.File({path: './test/truthy.js'}));
   });
 
+  it('should emit an error if the tests fail', function (done) {
+
+    var stream = Glab('-s -l');
+    var failure;
+
+    stream.once("error", function (error) { failure = error; });
+    stream.pipe(es.wait(function () {
+      expect(failure, 'no error').to.be.an.instanceOf(Error);
+      expect(failure.message, 'message').to.match(/exited with errors/i);
+      done();
+    }));
+    stream.end(new Gutil.File({path: './test/fail.js'}));
+  });
+
 });


### PR DESCRIPTION
This change causes the `gulp-lab` stream to emit an error if the `lab` process exits with an error code. This is useful for including `gulp-lab` in CI systems.
