### PR TITLE
Invoke lab with same node args used to run gulp.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Spawn = require('child_process').spawn;
+var child_process = require('child_process');
 var Through2 = require('through2');
 var Join = require('path').join;
 var PluginError = require('gulp-util').PluginError;
@@ -71,7 +71,7 @@ module.exports = function (options) {
 
 
     // Spawn process
-    var child = Spawn('node', args.concat(paths), {stdio: 'inherit'});
+    var child = child_process.spawn(process.execPath, process.execArgv.concat(args.concat(paths)), {stdio: 'inherit'});
 
     child.on('exit', function (code) {
       if (code !== 0 && emitErr) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "event-stream": "^3.1.5",
-    "lab": "~3.2.1"
+    "lab": "~3.2.1",
+    "sinon": "^1.10.3"
   }
 }


### PR DESCRIPTION
Currently `gulp-lab` assumes that the `node` executable is called "node" and that it is invoked without additional options. This can cause problems if a system uses `nodejs` as the node executable or if `gulp-lab` is being used to test a project leveraging the harmony extensions.

This change updates `gulp-lab` to pull the node process name and arguments from the `gulp` process.
