### PR TITLE
Support arrays as options

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,11 @@ module.exports = function (options) {
 
       args = args.concat(options.split(' '));
 
-    // Object options    
-    } else if (_isObject(options)) {
+    } else if (Array.isArray(options)) { // Array options
+
+      args = args.concat(options);
+
+    } else if (_isObject(options)) { // Object options
 
       if (!_isObject(options.opts)) {
 
@@ -54,16 +57,19 @@ module.exports = function (options) {
       }
 
       if (options.opts && typeof options.opts.emitLabError !== 'boolean') {
-        
+
         stream.emit('error', new PluginError(PLUGIN_NAME, 'Lab - Object property "emitLabError" must be a boolen!'));
         cb();
         return;
-      }      
+      }
 
       // cmd is optional
       if (_isString(options.args)) {
 
         args = args.concat(options.args.split(' '));
+      } else if (Array.isArray(options.args)) {
+
+        args = args.concat(options.args);
       }
 
       emitErr = options.opts.emitLabError;

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,14 @@ describe('index', function () {
     stream.end(new Gutil.File({path: './test/truthy.js'}));
   });
 
+  it('should run truthy test by gulp-lab module with Array options', function(done) {
+
+    var stream = Glab(['-v', '-l']);
+
+    stream.pipe(es.wait(done));
+    stream.end(new Gutil.File({path: './test/truthy.js'}));
+  });
+
   it('should emit an error if options object is passed with missing opts property', function (done) {
 
     var failure;
@@ -150,6 +158,25 @@ describe('index', function () {
     stream.once('error', function (error) { failure = error; });
     stream.pipe(es.wait(function () {
       expect(failure).to.equal(undefined);
+      done();
+    }));
+    stream.end(new Gutil.File({path: './test/fail.js'}));
+  });
+
+  it('should emit an error when running fail with Array arguments and filter on tests', function (done) {
+
+    var failure;
+    var stream = Glab({
+      args: ['-s', '-l', '-g should fail test'],
+      opts: {
+        emitLabError: true
+      }
+    });
+
+    stream.once('error', function (error) { failure = error; });
+    stream.pipe(es.wait(function () {
+      expect(failure, 'no error').to.be.an.instanceOf(Error);
+      expect(failure.message, 'message').to.match(/exited with errors/i);
       done();
     }));
     stream.end(new Gutil.File({path: './test/fail.js'}));


### PR DESCRIPTION
Splitting on space doesn't work for me, using an option (like -g) which takes arguments with potential spaces won't work this way.
I couldn't test the simple case with only an array because there's no reporting but it works.
