### PR TITLE
fix path replacing deprecated lab with @hapi/lab

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function (options) {
 
   // We expect that lab was declared as a project dependencies, and run directly its main script
   // this way, it can be executed on every platform.
-  var args = [Join(process.cwd(), 'node_modules', 'lab', 'bin', 'lab')];
+  var args = [Join(process.cwd(), 'node_modules', '@hapi', 'lab', 'bin', 'lab')];
 
   return Through2.obj(function (file, enc, cb) {
 


### PR DESCRIPTION
With this PR we force using @hapi/lab. 
If we want support old deprecated 'lab' we could check if file exists and fallback to older one (need fs)